### PR TITLE
More routine improvements

### DIFF
--- a/Routines/Barbarian/BarbarianRaekorIK.cs
+++ b/Routines/Barbarian/BarbarianRaekorIK.cs
@@ -137,7 +137,6 @@ namespace Trinity.Routines.Barbarian
         protected override bool ShouldFuriousCharge(out Vector3 position)
         {
             position = Vector3.Zero;
-            TrinityActor target = null;
 
             if (!Skills.Barbarian.FuriousCharge.CanCast())
                 return false;

--- a/Routines/DemonHunter/DemonHunterBase.cs
+++ b/Routines/DemonHunter/DemonHunterBase.cs
@@ -153,11 +153,11 @@ namespace Trinity.Routines.DemonHunter
                 return false;
 
             // Find a safespot with no monsters within kite range.
-            Core.Avoidance.Avoider.TryGetSafeSpot(out destination, 23f, 27f, Player.Position, 
+            Core.Avoidance.Avoider.TryGetSafeSpot(out destination, 33f, 37f, Player.Position, 
                 node => !TargetUtil.AnyMobsInRangeOfPosition(node.NavigableCenter, KiteDistance));
 
             // Vault is a fixed distance spell, predict our actual landing position
-            destination = MathEx.CalculatePointFrom(destination, ZetaDia.Me.Position, 25);
+            destination = MathEx.CalculatePointFrom(destination, ZetaDia.Me.Position, 35);
 
             // Prevent vaulting away from stuff that needs to be interacted with.
             if (ZetaDia.Actors.GetActorsOfType<DiaGizmo>().Any(g => g.Distance < 10f && g.ActorInfo.GizmoType != GizmoType.DestroyableObject))

--- a/Routines/DemonHunter/DemonHunterMarauderSettings.xaml
+++ b/Routines/DemonHunter/DemonHunterMarauderSettings.xaml
@@ -16,7 +16,8 @@
             <converters:EnumBooleanConverter x:Key="EnumBooleanConverter" />
             <converters:EnumVisibilityConverter x:Key="HiddenWhenEnumTrueConverter" Reverse="True"/>
             <converters:EnumVisibilityConverter x:Key="VisibleWhenEnumTrueConverter" />
-        </ResourceDictionary>
+            <converters:FlagsToBoolConverter x:Key="FlagsToValueConverter" />
+    </ResourceDictionary>
     </UserControl.Resources>
     <Border Padding="10">
         <Grid>
@@ -65,11 +66,11 @@
                         </WrapPanel>
                         <StackPanel Margin="0,5,0,0" Visibility="{Binding DataContext.Vengeance.UseMode, ConverterParameter=Selective, Converter={StaticResource VisibleWhenEnumTrueConverter}}">
                             <CheckBox ToolTip="Use when there are elites close nearby" 
-                                      IsChecked="{Binding DataContext.Epiphany.Reasons, ConverterParameter=Elites, Converter={converters:FlagsToBoolConverter}}">Elites nearby</CheckBox>
+                                      IsChecked="{Binding DataContext.Vengeance.Reasons, ConverterParameter=Elites, Converter={converters:FlagsToBoolConverter}}">Elites nearby</CheckBox>
                             <CheckBox ToolTip="Use when you are surrounded by enemies" 
-                                      IsChecked="{Binding DataContext.Epiphany.Reasons, ConverterParameter=Surrounded, Converter={converters:FlagsToBoolConverter}}">Surrounded</CheckBox>
+                                      IsChecked="{Binding DataContext.Vengeance.Reasons, ConverterParameter=Surrounded, Converter={converters:FlagsToBoolConverter}}">Surrounded</CheckBox>
                             <CheckBox ToolTip="Use when you're low on health" 
-                                      IsChecked="{Binding DataContext.Epiphany.Reasons, ConverterParameter=HealthEmergency, Converter={converters:FlagsToBoolConverter}}">Health emergency</CheckBox>                        </StackPanel>
+                                      IsChecked="{Binding DataContext.Vengeance.Reasons, ConverterParameter=HealthEmergency, Converter={converters:FlagsToBoolConverter}}">Health emergency</CheckBox>                        </StackPanel>
                     </StackPanel>
                 </GroupBox>                
                 <GroupBox>

--- a/Routines/Monk/MonkSWKWoL.cs
+++ b/Routines/Monk/MonkSWKWoL.cs
@@ -290,7 +290,7 @@ namespace Trinity.Routines.Monk
             private static readonly SkillSettings EpiphanyDefaults = new SkillSettings
             {
                 UseMode = UseTime.Selective,
-                Reasons = UseReasons.Elites | UseReasons.HealthEmergency
+                Reasons = UseReasons.Elites | UseReasons.Surrounded | UseReasons.HealthEmergency,
             };
 
             private static readonly SkillSettings DashingStrikeDefaults = new SkillSettings

--- a/Routines/Wizard/WizardChannelMeteor.cs
+++ b/Routines/Wizard/WizardChannelMeteor.cs
@@ -177,7 +177,7 @@ namespace Trinity.Routines.Wizard
             return target != null;
         }
 
-        bool ShouldContinueChanneling(out TrinityActor target)
+        private bool ShouldContinueChanneling(out TrinityActor target)
         {
             Vector3 position;
             var interruptForTeleport = ShouldTeleport(out position);


### PR DESCRIPTION
* DemonHunterBase: fixed Vault distance (from 25f to 35f)
* DemonHunterMarauder: updated routine to work with the new Natalya's/Marauder variation of the build
* DemonHunterMarauder: should now only start kiting if enemies nearby are actually dealing damage
* DemonHunterMarauderSettings: fixed wrong DataContexts and added missing resource entry which was causing settings to not be saved/loaded
* WitchDoctorArachyrFirebats: should now cast SpiritWalk and try to walk to the densest cluster in order to get maximum SoulHarvest stacks as quickly as possible (only applies to GRifts)